### PR TITLE
Copy /system/etc/g.prop to allow being picked up by opengapps-installer

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -402,6 +402,7 @@ vendorApp="$(ls -d /vendor/bundled-app/* 2>/dev/null)"
 
 # prepare NewSystemPath & NewVendorPath
 cp -af /system/build.prop $INSTALLER/build.prop
+cp -af /system/etc/g.prop $INSTALLER/g.prop
 umount -l /system_root 2>/dev/null
 umount -l /system 2>/dev/null
 mount_check /system
@@ -409,6 +410,8 @@ NewSystemPath=$modPath/system
 NewVendorPath=$NewSystemPath/vendor
 mkdir $NewSystemPath
 bind_mount $NewSystemPath /system
+mkdir $NewSystemPath/etc
+cp -af $INSTALLER/g.prop $NewSystemPath/etc/g.prop
 if [ -d /vendor ]; then
   umount -l /vendor 2>/dev/null
   mount_check /vendor


### PR DESCRIPTION
Apparently MagicGapps and OpenGapps detection of architecture is different.
On my device (which supports both ARM64 and ARM) MagicGapps detects ARM64 while opengapps detects ARM which results in not being able to install either.

The device (Amazon Fire HD 10) has the following properties set:
`[ro.product.cpu.abi]: [arm64-v8a]
[ro.product.cpu.abilist32]: [armeabi-v7a,armeabi]
[ro.product.cpu.abilist64]: []
[ro.product.cpu.abilist]: [armeabi-v7a,armeabi]`

by adding the follwing lines to _/system/etc/g.prop_ 
`ro.product.cpu.abilist=arm64-v8a,arm64,armeabi-v7a,armeabi
ro.product.cpu.abilist64=arm64-v8a,arm64`

I can get the opengapps installer to pick up ARM64 but can't install due to size limitations.
Adding them to _/system/build.prop_ results in an unbootable system.

This patch allows the file to get picked up properly when installed through Magisk.
That way I can install the ARM64 open-gapps and they work fine.
